### PR TITLE
add short_open_tag directive for php in rc.local

### DIFF
--- a/includes/module_action.php
+++ b/includes/module_action.php
@@ -89,7 +89,7 @@ if($service != "") {
             //exec("$bin_danger \"$exec\"" ); //DEPRECATED
             exec_fruitywifi($exec);
             
-            $exec = "sed -i 's/^exit 0/php $srv_dir\/FruityWifi-autostart.php\\nexit 0/g' /etc/rc.local";
+            $exec = "sed -i 's/^exit 0/php -d short_open_tag=on $srv_dir\/FruityWifi-autostart.php\\nexit 0/g' /etc/rc.local";
             //exec("$bin_danger \"$exec\"" ); //DEPRECATED
             exec_fruitywifi($exec);
             


### PR DESCRIPTION
Many PHP scripts in the project use short open tag `<?`, but default configurations in php.ini have often short open tag disabled.

To fix this, php can have this directive set directly in /etc/rc.local.